### PR TITLE
Remove footer credit line from localized HTML files

### DIFF
--- a/index_ja.html
+++ b/index_ja.html
@@ -183,7 +183,6 @@
     <footer class="bg-dark text-white text-center py-4">
         <div class="container">
             <p class="mb-0">&copy; 2025 ViewRingo. 全著作権所有。</p>
-            <p class="mb-0"><small>ViewRingo チームが <i class="fas fa-heart text-danger"></i> で作成</small></p>
         </div>
     </footer>
 

--- a/index_ko.html
+++ b/index_ko.html
@@ -183,7 +183,6 @@
     <footer class="bg-dark text-white text-center py-4">
         <div class="container">
             <p class="mb-0">&copy; 2025 ViewRingo. 모든 권리 보유.</p>
-            <p class="mb-0"><small>ViewRingo 팀이 <i class="fas fa-heart text-danger"></i>로 제작</small></p>
         </div>
     </footer>
 

--- a/index_zh.html
+++ b/index_zh.html
@@ -183,7 +183,6 @@
     <footer class="bg-dark text-white text-center py-4">
         <div class="container">
             <p class="mb-0">&copy; 2025 ViewRingo. 保留所有权利。</p>
-            <p class="mb-0"><small>由 ViewRingo 团队用 <i class="fas fa-heart text-danger"></i> 打造</small></p>
         </div>
     </footer>
 


### PR DESCRIPTION
Eliminate the credit line from the footer in Japanese, Korean, and Chinese HTML files to streamline the content.